### PR TITLE
Improve clarity of count-down/-up behavior.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,10 +155,10 @@ Steady state display::
 
     0         1         
     01234567890123456789
-    JB#   n/N :  MM:SS.s
+    GAME      :  MM:SS.s
        NN⚑: R=NN Y=NN
     messagemessagemessag
-    JAILBREAK :  MM:SS.s
+    JB#   n/N :  MM:SS.s
 
 Last round display::
 

--- a/ctfws-lcd.lua
+++ b/ctfws-lcd.lua
@@ -60,10 +60,9 @@ local function drawSteadyTopLine(self,rix,maxt,ela)
   local ctfws = self.ctfws
   if self.dl_elapsed == nil then
     lcd:put(lcd:locate(0,0), "                    ")
-    if     rix == 0            then lcd:put(lcd:locate(0,0), "SETUP     :")
-    elseif rix == ctfws.rounds then lcd:put(lcd:locate(0,0), "GAME      :")
-    elseif ctfws.rounds >= 11  then lcd:put(lcd:locate(0,0), string.format("JB# %2d/%2d :",rix,ctfws.rounds-1))
-    else                            lcd:put(lcd:locate(0,0), string.format("JB#   %d/%d :",rix,ctfws.rounds-1))
+    if rix == 0
+      then lcd:put(lcd:locate(0,0), "SETUP     :")
+      else lcd:put(lcd:locate(0,0), "GAME      :")
     end
   end
   drawDS(lcd,0,13,maxt,self.dl_elapsed,ela); self.dl_elapsed = ela
@@ -76,7 +75,10 @@ local function drawSteadyBotLine(self,rix,maxt,rem)
     if rix == 0 then
       lcd:put(lcd:locate(3,0), "START IN  :")
     elseif rix < ctfws.rounds then
-      lcd:put(lcd:locate(3,0), "JAILBREAK :")
+      if ctfws.rounds >= 11
+        then lcd:put(lcd:locate(3,0), string.format("JB# %2d/%2d :",rix,ctfws.rounds-1))
+        else lcd:put(lcd:locate(3,0), string.format("JB#   %d/%d :",rix,ctfws.rounds-1))
+      end
     else
       lcd:put(lcd:locate(3,0), "GAME END  :")
     end
@@ -113,9 +115,9 @@ end
 -- the next message or event
 local function drawTimes(self)
   local ctfws = self.ctfws
-  local rix, maxt, ela = ctfws:times(rtctime.get)
+  local rix, roundD, roundEla, gameEla = ctfws:times(rtctime.get)
   if rix == nil then
-    drawNoGame(self.lcd, maxt)
+    drawNoGame(self.lcd, roundD)
     if rix ~= self.dl_round then
       self.dl_round = rix
       attention(self,true)
@@ -128,8 +130,8 @@ local function drawTimes(self)
     self.dl_elapsed = nil -- force redraws of times on round boundaries
     self.dl_remain  = nil
   end
-  drawSteadyTopLine(self,rix,maxt,ela)
-  drawSteadyBotLine(self,rix,maxt,maxt-ela)
+  drawSteadyTopLine(self,rix,roundD,gameEla)
+  drawSteadyBotLine(self,rix,roundD,roundD-roundEla)
   return true
 end
 

--- a/ctfws.lua
+++ b/ctfws.lua
@@ -39,17 +39,17 @@ local function times(self, nowf)
   local elapsed = (now_sec - self.startT) * 10 + math.floor(now_usec / 100000)
 
   if elapsed < self.setupD then
-    return 0, self.setupD, elapsed
+    return 0, self.setupD, elapsed, elapsed -- treat setup (round 0) as a self-contained "game"
   end
 
-  elapsed = elapsed - self.setupD
+  gameElapsed = elapsed - self.setupD
 
-  local rounds = math.floor(elapsed / self.roundD)
+  local rounds = math.floor(gameElapsed / self.roundD)
   if rounds >= self.rounds
    then return nil, "TIME IS UP"
    else -- game still in progress
-     local roundElapsed = elapsed - rounds * self.roundD
-     return rounds + 1, self.roundD, roundElapsed
+     local roundElapsed = gameElapsed - rounds * self.roundD
+     return rounds + 1, self.roundD, roundElapsed, gameElapsed
   end
 end
 


### PR DESCRIPTION
The top line counts up through the setup period, then continuously from 0:00
through the entire game.  The bottom line counts down to game start, to each
jailbreak, and to game end.

Resolves #3.